### PR TITLE
Add device selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 *.log
+*.swp
+*.swo

--- a/examples/balls/index.ts
+++ b/examples/balls/index.ts
@@ -1,6 +1,5 @@
 import { DAC } from '@laser-dac/core';
-import { Simulator } from '@laser-dac/simulator';
-import { EtherDream } from '@laser-dac/ether-dream';
+import { getDevices } from '@laser-dac/device-selector';
 import { Scene, Rect } from '@laser-dac/draw';
 import { Ball } from './Ball';
 
@@ -8,10 +7,7 @@ const NUMBER_OF_BALLS = 4;
 
 (async () => {
   const dac = new DAC();
-  dac.use(new Simulator());
-  if (process.env.DEVICE) {
-    dac.use(new EtherDream());
-  }
+  dac.useAll(await getDevices());
   await dac.start();
 
   const balls: Ball[] = [];

--- a/examples/font/index.ts
+++ b/examples/font/index.ts
@@ -1,6 +1,5 @@
 import { DAC } from '@laser-dac/core';
-import { Simulator } from '@laser-dac/simulator';
-import { EtherDream } from '@laser-dac/ether-dream';
+import { getDevices } from '@laser-dac/device-selector';
 import { Scene, HersheyFont, loadHersheyFont, Timeline } from '@laser-dac/draw';
 import * as path from 'path';
 
@@ -38,10 +37,7 @@ const textAnimation = new Timeline({
 
 (async () => {
   const dac = new DAC();
-  dac.use(new Simulator());
-  if (process.env.DEVICE) {
-    dac.use(new EtherDream());
-  }
+  dac.useAll(await getDevices());
   await dac.start();
 
   const scene = new Scene();

--- a/examples/ilda-animation/index.ts
+++ b/examples/ilda-animation/index.ts
@@ -1,6 +1,5 @@
 import { DAC } from '@laser-dac/core';
-import { Simulator } from '@laser-dac/simulator';
-import { EtherDream } from '@laser-dac/ether-dream';
+import { getDevices } from '@laser-dac/device-selector';
 import { Scene, Ilda, loadIldaFile } from '@laser-dac/draw';
 import * as path from 'path';
 
@@ -8,10 +7,7 @@ const boeing = loadIldaFile(path.resolve(__dirname, './boeing.ild'));
 
 (async () => {
   const dac = new DAC();
-  dac.use(new Simulator());
-  if (process.env.DEVICE) {
-    dac.use(new EtherDream());
-  }
+  dac.useAll(await getDevices());
   await dac.start();
 
   const scene = new Scene();

--- a/examples/pong/renderer.ts
+++ b/examples/pong/renderer.ts
@@ -1,6 +1,5 @@
 import { DAC } from '@laser-dac/core';
-import { Simulator } from '@laser-dac/simulator';
-import { EtherDream } from '@laser-dac/ether-dream';
+import { getDevices } from '@laser-dac/device-selector';
 import { Scene, Rect } from '@laser-dac/draw';
 import { Player } from './Player';
 import { Ball } from './Ball';
@@ -27,10 +26,7 @@ export class Renderer {
 
   async start() {
     const dac = new DAC();
-    dac.use(new Simulator());
-    if (process.env.DEVICE) {
-      dac.use(new EtherDream());
-    }
+    dac.useAll(await getDevices());
     await dac.start();
 
     const ball = new Ball({

--- a/examples/square-interactive/renderer.ts
+++ b/examples/square-interactive/renderer.ts
@@ -1,6 +1,5 @@
 import { DAC } from '@laser-dac/core';
-import { Simulator } from '@laser-dac/simulator';
-import { EtherDream } from '@laser-dac/ether-dream';
+import { getDevices } from '@laser-dac/device-selector';
 import { Scene, Rect, loadIldaFile, Ilda } from '@laser-dac/draw';
 import * as path from 'path';
 
@@ -48,10 +47,7 @@ export class Renderer {
 
   async start() {
     const dac = new DAC();
-    dac.use(new Simulator());
-    if (process.env.DEVICE) {
-      dac.use(new EtherDream());
-    }
+    dac.useAll(await getDevices());
     await dac.start();
 
     const scene = new Scene();

--- a/examples/static-shapes/index.ts
+++ b/examples/static-shapes/index.ts
@@ -1,14 +1,10 @@
 import { DAC } from '@laser-dac/core';
-import { Simulator } from '@laser-dac/simulator';
-import { Helios } from '@laser-dac/helios';
+import { getDevices } from '@laser-dac/device-selector';
 import { Scene, Rect, Path, Line } from '@laser-dac/draw';
 
 (async () => {
   const dac = new DAC();
-  dac.use(new Simulator());
-  if (process.env.DEVICE) {
-    dac.use(new Helios());
-  }
+  dac.useAll(await getDevices());
   await dac.start();
 
   const scene = new Scene({

--- a/examples/svg-path/index.ts
+++ b/examples/svg-path/index.ts
@@ -1,6 +1,5 @@
 import { DAC } from '@laser-dac/core';
-import { Simulator } from '@laser-dac/simulator';
-import { EtherDream } from '@laser-dac/ether-dream';
+import { getDevices } from '@laser-dac/device-selector';
 import { Scene, Svg, loadSvgFile } from '@laser-dac/draw';
 import * as path from 'path';
 
@@ -8,10 +7,8 @@ const logoFile = loadSvgFile(path.resolve(__dirname, './logo.svg'));
 
 (async () => {
   const dac = new DAC();
-  dac.use(new Simulator());
-  if (process.env.DEVICE) {
-    dac.use(new EtherDream());
-  }
+  dac.useAll(await getDevices());
+
   await dac.start();
 
   const scene = new Scene({

--- a/packages/beyond/src/BeyondLib.ts
+++ b/packages/beyond/src/BeyondLib.ts
@@ -26,7 +26,10 @@ const libPath = path
   // dont'get placed inside the "app.asar" bundle, but instead get placed in a separate directory called "app.asar.unpacked"
   .replace('app.asar', 'app.asar.unpacked');
 
-const BeyondLib = ffi.Library(libPath, {
+// Even Windows 64-bit is called win32 here.
+const isSupported = process.platform === "win32";
+
+const BeyondLib = isSupported && ffi.Library(libPath, {
   ldbCreate: ['int', []],
   ldbDestroy: ['int', []],
   ldbBeyondExeReady: ['int', []],

--- a/packages/beyond/src/index.ts
+++ b/packages/beyond/src/index.ts
@@ -13,6 +13,9 @@ export class Beyond extends Device {
   private started = false;
 
   async start() {
+    if (!this.isSupported()) {
+      return false;
+    }
     this.stop();
     beyondLib.ldbCreate();
     this.started = true;
@@ -35,6 +38,10 @@ export class Beyond extends Device {
     if (this.interval) {
       clearInterval(this.interval);
     }
+  }
+
+  isSupported(): boolean {
+    return process.platform === "win32";
   }
 
   private convertPoint(p: Point) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,10 @@ export abstract class Device {
   // This is for any last-minute synchronous cleanup so the laser doesn't
   // stay on after the program stops.
   onShutdownSync(): void {};
+
+  isSupported(): boolean {
+    return true;
+  };
 }
 
 export class DAC {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,10 @@ export class DAC {
     shutdownCallbacks.push(device.onShutdownSync);
   }
 
+  useAll(devices: Device[]) {
+    devices.forEach((device) => this.use(device));
+  }
+
   remove(device: Device) {
     const index = this.devices.indexOf(device);
     if (index) {

--- a/packages/device-selector/README.md
+++ b/packages/device-selector/README.md
@@ -1,0 +1,35 @@
+# @laser-dac/device-selector
+
+This package is an easy adapter for multiple devices.
+
+```
+yarn add @laser-dac/device-selector
+npm i @laser-dac/device-selector
+```
+
+## Usage
+
+```js
+import { DAC } from '@laser-dac/core';
+import { getDevices } from '@laser-dac/device-selector';
+
+const dac = new DAC();
+// Automatically select a supported device and a Simulator.
+dac.useAll(await getDevices());
+const started = await dac.start();
+if (started) {
+  const pps = 30000; // points per second
+  const fps = 120; // frames per second
+  // draw a horizontal red line from left to right in the center
+  // @laser-dac/draw can help you with drawing points!
+  const scene = {
+    points: [
+      { x: 0.1, y: 0.5, r: 1, g: 0, b: 0 },
+      { x: 0.9, y: 0.5, r: 1, g: 0, b: 0 }
+    ]
+  };
+  dac.stream(scene, pps, fps);
+}
+```
+
+See for more usage info and examples the [Laser DAC project on GitHub](https://github.com/Volst/laser-dac).

--- a/packages/device-selector/package.json
+++ b/packages/device-selector/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@laser-dac/device-selector",
+  "version": "0.4.1",
+  "description": "Device-selecting adapter for laser-dac",
+  "license": "MIT",
+  "author": "Sterling Hirsh <sterling@sterlinghirsh.com>",
+  "repository": "Volst/laser-dac",
+  "keywords": [
+    "laser"
+  ],
+  "engines": {
+    "node": ">=8.0"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@laser-dac/core": "^0.4.1",
+    "@laser-dac/beyond": "^0.3.0",
+    "@laser-dac/easylase": "^0.2.0",
+    "@laser-dac/ether-dream": "^0.4.1",
+    "@laser-dac/helios": "^0.3.0",
+    "@laser-dac/laserdock": "^0.4.0",
+    "@laser-dac/simulator": "^0.3.3"
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "watch": "tsc -p tsconfig.build.json --watch",
+    "prepublishOnly": "npm run -s build"
+  }
+}

--- a/packages/device-selector/src/index.ts
+++ b/packages/device-selector/src/index.ts
@@ -1,0 +1,52 @@
+import { Device } from '@laser-dac/core';
+
+import { Simulator } from '@laser-dac/simulator';
+
+import { Beyond } from '@laser-dac/beyond';
+import { Easylase } from '@laser-dac/easylase';
+import { EtherDream } from '@laser-dac/ether-dream';
+import { Helios } from '@laser-dac/helios';
+import { Laserdock } from '@laser-dac/laserdock';
+
+const apis: Record<string, {new (): Device}> = {
+  helios: Helios,
+  laserdock: Laserdock,
+  beyond: Beyond,
+  easylase: Easylase,
+  'ether-dream': EtherDream // This one is a bit slower to check.
+};
+
+// Get the first DAC that works.
+export async function autoSelect(): Promise<Device|null> {
+  console.log("Searching for DAC in " + Object.keys(apis).join(', '));
+  for (const api in apis) {
+    const dac = new apis[api]();
+    if (await dac.start()) {
+      console.log("Auto Selected DAC " + api);
+      await dac.stop();
+      return dac;
+    }
+  }
+  console.log("No DAC found");
+  return null;
+}
+
+// Get a Simulator and the first autodetected device.
+// TODO: Get multiple devices instead of just the first?
+export async function getDevices(): Promise<Device[]> {
+  const devices: Device[] = [new Simulator()];
+  const requestedDevice = process.env.DEVICE;
+
+  if (requestedDevice) {
+    if (requestedDevice in apis) {
+      devices.push(new apis[requestedDevice]());
+    } else {
+      const autoSelected = await autoSelect();
+      if (autoSelected) {
+        devices.push(autoSelected);
+      }
+    }
+  }
+
+  return devices;
+}

--- a/packages/device-selector/tsconfig.build.json
+++ b/packages/device-selector/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/index.ts"]
+}

--- a/packages/easylase/src/EasylaseLib.ts
+++ b/packages/easylase/src/EasylaseLib.ts
@@ -37,7 +37,10 @@ const libPath = path
   // dont'get placed inside the "app.asar" bundle, but instead get placed in a separate directory called "app.asar.unpacked"
   .replace('app.asar', 'app.asar.unpacked');
 
-const EasylaseLib = ffi.Library(libPath, {
+// Even Windows 64-bit is called win32 here.
+const isSupported = process.platform === "win32";
+
+const EasylaseLib = isSupported && ffi.Library(libPath, {
   jmLaserEnumerateDevices: ['int', []],
   jmLaserStopOutput: ['int', ['int']],
   jmLaserCloseDevice: ['int', ['int']],

--- a/packages/easylase/src/index.ts
+++ b/packages/easylase/src/index.ts
@@ -7,6 +7,10 @@ export class Easylase extends Device {
   deviceHandle?: number;
 
   async start() {
+    if (!this.isSupported()) {
+      return false;
+    }
+
     this.stop();
     const cards = easylaseLib.enumerateDevices();
     if (cards) {
@@ -30,6 +34,10 @@ export class Easylase extends Device {
     if (this.interval) {
       clearInterval(this.interval);
     }
+  }
+
+  isSupported(): boolean {
+    return process.platform === "win32";
   }
 
   private convertPoint(p: Point) {


### PR DESCRIPTION
Instead of having each example specify which device it wants to use, we can call getDevices(). This always adds a Simulator device, but if process.env.DEVICE is truthy, it will search for a real DAC. If process.env.DEVICE is the name of a DAC, it will use that without searching.

This pull also adds a method to Device so we can ask if the device is supported on the current system. Right now, this is only used to check the OS on windows-only DACs.