### PR TITLE
Fix helios resolution

### DIFF
--- a/packages/helios/src/convert.ts
+++ b/packages/helios/src/convert.ts
@@ -1,6 +1,6 @@
-// The Helios DAC firmware uses 12-bit integers for the resolution, ranging from 0 to 4096.
+// The Helios DAC firmware uses 12-bit integers for the resolution, ranging from 0 to 4095.
 // Source: https://github.com/Grix/helios_dac/blob/master/sdk/HeliosDac.h
-export const XY_RESOLUTION = 4096;
+export const XY_RESOLUTION = 4095;
 export const COLOR_RESOLUTION = 255;
 
 export function relativeToPosition(n: number) {

--- a/packages/helios/src/convert.ts
+++ b/packages/helios/src/convert.ts
@@ -3,7 +3,12 @@
 export const XY_RESOLUTION = 4095;
 export const COLOR_RESOLUTION = 255;
 
-export function relativeToPosition(n: number) {
+export function relativeToX(n: number) {
+  return Math.floor(n * XY_RESOLUTION);
+}
+
+// Helios has 0 Y at the bottom, but laser-dac has 0 Y at the top.
+export function relativeToY(n: number) {
   return Math.floor((1 - n) * XY_RESOLUTION);
 }
 

--- a/packages/helios/src/index.ts
+++ b/packages/helios/src/index.ts
@@ -1,6 +1,6 @@
 import { Device } from '@laser-dac/core';
 import * as heliosLib from './HeliosLib';
-import { relativeToPosition, relativeToColor } from './convert';
+import { relativeToX, relativeToY, relativeToColor } from './convert';
 
 // This controls the intensity signal of points written to the DAC.
 // For many laser projectors this won't make a difference, but some projectors map this to the shutter so the laser won't turn on if we don't pass the max value.
@@ -30,8 +30,8 @@ export class Helios extends Device {
 
   private convertPoint(p: heliosLib.IPoint) {
     return {
-      x: relativeToPosition(p.x),
-      y: relativeToPosition(p.y),
+      x: relativeToX(p.x),
+      y: relativeToY(p.y),
       r: relativeToColor(p.r),
       g: relativeToColor(p.g),
       b: relativeToColor(p.b),


### PR DESCRIPTION
Helios had its resolution set to 4096, but it should have been 4095 to make 4096 possible values. I also flipped the X axis since running the svg example showed the text backwards.