### PR TITLE
Dynamic scene

### DIFF
--- a/examples/balls-dynamic/Ball.ts
+++ b/examples/balls-dynamic/Ball.ts
@@ -1,0 +1,65 @@
+import { Circle } from '@laser-dac/draw';
+import Victor = require('victor');
+
+interface BallOptions {
+  x: number;
+  y: number;
+  radius: number;
+}
+
+export class Ball {
+  radius: number;
+  x: number;
+  y: number;
+  vector: Victor = new Victor(
+    (Math.random() - 0.5) / 2,
+    (Math.random() - 0.5) / 2
+  );
+
+  constructor(options: BallOptions) {
+    this.x = options.x;
+    this.y = options.y;
+    this.radius = options.radius;
+  }
+
+  update = (timeStep: number) => {
+    this.x += this.vector.x * timeStep;
+    this.y += this.vector.y * timeStep;
+
+    this.updateBounds();
+  };
+
+  updateBounds = () => {
+    // Left bound.
+    if (this.x - this.radius <= 0) {
+      this.x = this.radius;
+      this.vector.invertX();
+    }
+
+    // Right bound.
+    if (this.x + this.radius > 1) {
+      this.x = 1 - this.radius;
+      this.vector.invertX();
+    }
+
+    // Top bound.
+    if (this.y - this.radius <= 0) {
+      this.y = this.radius;
+      this.vector.invertY();
+    }
+
+    // Bottom bound.
+    if (this.y + this.radius > 1) {
+      this.y = 1 - this.radius;
+      this.vector.invertY();
+    }
+  };
+
+  draw = () =>
+    new Circle({
+      x: this.x,
+      y: this.y,
+      radius: this.radius,
+      color: [0, 1, 0]
+    });
+}

--- a/examples/balls-dynamic/index.ts
+++ b/examples/balls-dynamic/index.ts
@@ -45,6 +45,46 @@ const NUMBER_OF_BALLS = 4;
     lastTime = curTime;
   }
 
-  scene.start(renderFrame);
-  dac.stream(scene);
+  /** timeStep and curTime both floats in seconds */
+  function updateScene(timeStep: number) {
+    const bounds = new Rect({
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      color: [0, 1, 0]
+    });
+    scene.add(bounds);
+
+    balls.forEach(ball => {
+      ball.update(timeStep);
+      scene.add(ball.draw());
+    });
+  }
+
+  const dynamicScene = new Scene({
+    resolution: 70
+  });
+
+  updateScene(0, 0);
+  let curTime = 0;
+  let timeStep = 0;
+  const maxPoints = 4000;
+  const pointsRate = 30000;
+
+  dac.setPointsRate(pointsRate);
+
+  function generateFrames() {
+    while (dynamicScene.points.length < maxPoints * 2) {
+      updateScene(timeStep);
+      dynamicScene.points = dynamicScene.points.concat(scene.points);
+      timeStep = scene.points.length / pointsRate;
+      scene.reset();
+      curTime += timeStep;
+    }
+  }
+
+  setInterval(generateFrames, 10);
+
+  dac.streamDynamic(dynamicScene);
 })();

--- a/examples/balls-dynamic/index.ts
+++ b/examples/balls-dynamic/index.ts
@@ -1,6 +1,6 @@
 import { DAC } from '@laser-dac/core';
 import { getDevices } from '@laser-dac/device-selector';
-import { Scene, Rect } from '@laser-dac/draw';
+import { Scene, DynamicScene, Rect } from '@laser-dac/draw';
 import { Ball } from './Ball';
 
 const NUMBER_OF_BALLS = 4;
@@ -21,32 +21,7 @@ const NUMBER_OF_BALLS = 4;
     );
   }
 
-  const scene = new Scene({
-    resolution: 70
-  });
-
-  let lastTime = Date.now();
-  function renderFrame() {
-    const bounds = new Rect({
-      x: 0,
-      y: 0,
-      width: 1,
-      height: 1,
-      color: [0, 1, 0]
-    });
-    scene.add(bounds);
-
-    const curTime = Date.now();
-    const timeStep = (curTime - lastTime) / 1000;
-    balls.forEach(ball => {
-      ball.update(timeStep);
-      scene.add(ball.draw());
-    });
-    lastTime = curTime;
-  }
-
-  /** timeStep and curTime both floats in seconds */
-  function updateScene(timeStep: number) {
+  function updateScene(scene: Scene): Scene {
     const bounds = new Rect({
       x: 0,
       y: 0,
@@ -57,34 +32,17 @@ const NUMBER_OF_BALLS = 4;
     scene.add(bounds);
 
     balls.forEach(ball => {
-      ball.update(timeStep);
+      ball.update(scene.timeStep);
       scene.add(ball.draw());
     });
   }
 
-  const dynamicScene = new Scene({
-    resolution: 70
-  });
-
-  updateScene(0, 0);
-  let curTime = 0;
-  let timeStep = 0;
-  const maxPoints = 4000;
   const pointsRate = 30000;
 
-  dac.setPointsRate(pointsRate);
-
-  function generateFrames() {
-    while (dynamicScene.points.length < maxPoints * 2) {
-      updateScene(timeStep);
-      dynamicScene.points = dynamicScene.points.concat(scene.points);
-      timeStep = scene.points.length / pointsRate;
-      scene.reset();
-      curTime += timeStep;
-    }
-  }
-
-  setInterval(generateFrames, 10);
+  const dynamicScene = new DynamicScene(updateScene, {
+    pointsRate,
+    resolution: 70
+  });
 
   dac.streamDynamic(dynamicScene);
 })();

--- a/examples/balls-dynamic/index.ts
+++ b/examples/balls-dynamic/index.ts
@@ -1,0 +1,50 @@
+import { DAC } from '@laser-dac/core';
+import { getDevices } from '@laser-dac/device-selector';
+import { Scene, Rect } from '@laser-dac/draw';
+import { Ball } from './Ball';
+
+const NUMBER_OF_BALLS = 4;
+
+(async () => {
+  const dac = new DAC();
+  dac.useAll(await getDevices());
+  await dac.start();
+
+  const balls: Ball[] = [];
+  for (let i = 0; i < NUMBER_OF_BALLS; i++) {
+    balls.push(
+      new Ball({
+        x: Math.random(),
+        y: Math.random(),
+        radius: Math.random() / 5 + 0.05
+      })
+    );
+  }
+
+  const scene = new Scene({
+    resolution: 70
+  });
+
+  let lastTime = Date.now();
+  function renderFrame() {
+    const bounds = new Rect({
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      color: [0, 1, 0]
+    });
+    scene.add(bounds);
+
+    const curTime = Date.now();
+    const timeStep = (curTime - lastTime) / 1000;
+    balls.forEach(ball => {
+      ball.update(timeStep);
+      scene.add(ball.draw());
+    });
+    lastTime = curTime;
+  }
+
+  scene.start(renderFrame);
+  dac.stream(scene);
+})();

--- a/examples/calibration/index.ts
+++ b/examples/calibration/index.ts
@@ -15,7 +15,7 @@ const wss = new WebSocketServer({ server });
 
 server.on('request', app);
 server.listen(PORT, function() {
-  console.log(`Started Square Interactive demo on http://localhost:${PORT}`);
+  console.log(`Started Calibration Interface on http://localhost:${PORT}`);
 });
 
 wss.on('connection', function connection(ws, req) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,9 +21,16 @@ export abstract class Device {
   abstract start(): Promise<boolean>;
   abstract stop(): void;
   abstract stream(scene: Scene, pointsRate: number, fps: number): void;
+
+  streamDynamic(scene: Scene): void {
+    // Devices that haven't been adapted to support dynamic streaming will
+    // just do a 30fps static stream for now.
+    this.stream(scene, this.pointsRate, 30);
+  }
+
   // This is for any last-minute synchronous cleanup so the laser doesn't
   // stay on after the program stops.
-  onShutdownSync(): void {};
+  onShutdownSync(): void {}
 
   isSupported(): boolean {
     return true;
@@ -84,6 +91,12 @@ export class DAC {
   stream(scene: Scene, pointsRate = DEFAULT_POINTS_RATE, fps = DEFAULT_FPS) {
     for (const device of this.devices) {
       device.stream(scene, pointsRate, fps);
+    }
+  }
+
+  streamDynamic(scene: Scene) {
+    for (const device of this.devices) {
+      device.streamDynamic(scene);
     }
   }
 

--- a/packages/draw/src/Path.ts
+++ b/packages/draw/src/Path.ts
@@ -99,6 +99,7 @@ export class Path extends Shape {
     // use the value from SceneOptions at render time. The same goes
     // for waitAmount.
     const blankingAmount = this.blankingAmount ?? options.blankingPoints;
+    const waitAmount = this.waitAmount ?? options.maxWaitPoints;
 
     const points = pathData.commands.reduce(
       (accumulator: Point[], command: SVGCommand) => {
@@ -254,7 +255,7 @@ export class Path extends Shape {
             x: lastPoint.x,
             y: lastPoint.y,
             color: [lastPoint.r, lastPoint.g, lastPoint.b],
-            amount: Math.floor(this.waitAmount * relativeAngle)
+            amount: Math.floor(waitAmount * relativeAngle)
           });
           wait = waitShape.draw();
         }

--- a/packages/draw/src/Scene.ts
+++ b/packages/draw/src/Scene.ts
@@ -66,4 +66,10 @@ export class Scene {
   setOptions(options: Partial<SceneOptions>) {
     this.options = Object.assign(this.options, options);
   }
+
+  getPoints(numPoints: number): Point[] {
+    const chunk = this.points.slice(0, numPoints);
+    this.points = this.points.slice(numPoints);
+    return chunk;
+  }
 }

--- a/packages/draw/src/Scene.ts
+++ b/packages/draw/src/Scene.ts
@@ -10,6 +10,7 @@ export interface SceneOptions {
   blankingPoints: number;
   // This value determines how many times a Wait-point should be applied for the sharpest possible angles (360 degree angles).
   maxWaitPoints: number;
+  pointsRate: number;
 }
 
 const defaultOptions: SceneOptions = {
@@ -17,6 +18,7 @@ const defaultOptions: SceneOptions = {
   fps: 30,
   blankingPoints: 24,
   maxWaitPoints: 10,
+  pointsRate: 30000,
 };
 
 type TransformFn = (points: Point[]) => Point[];
@@ -71,5 +73,35 @@ export class Scene {
     const chunk = this.points.slice(0, numPoints);
     this.points = this.points.slice(numPoints);
     return chunk;
+  }
+}
+
+type UpdateFn = (scene: DynamicScene) => void;
+
+export class DynamicScene extends Scene {
+  curTime = 0;
+  timeStep = 0;
+  updateScene: UpdateFn;
+
+  constructor(updateScene: UpdateFn, options: Partial<SceneOptions> = {}) {
+    super(options);
+    this.updateScene = updateScene;
+  }
+
+  getPoints(numPoints: number): Point[] {
+    this.preparePoints(numPoints);
+    return super.getPoints(numPoints);
+  }
+
+  preparePoints(numPoints: number): void {
+    //console.log(`Preparing, starting with ${this.points.length} points`);
+    while (this.points.length < numPoints) {
+      const numPointsPre = this.points.length;
+      this.updateScene(this);
+      const addedPoints = this.points.length - numPointsPre;
+      //console.log(`Added ${addedPoints} points`);
+      this.timeStep = addedPoints / this.options.pointsRate;
+      this.curTime += this.timeStep;
+    }
   }
 }

--- a/packages/draw/src/index.ts
+++ b/packages/draw/src/index.ts
@@ -1,4 +1,4 @@
-export { Scene } from './Scene';
+export { Scene, DynamicScene } from './Scene';
 export { Line } from './Line';
 export { Rect } from './Rect';
 export { Circle } from './Circle';

--- a/packages/helios/src/index.ts
+++ b/packages/helios/src/index.ts
@@ -298,6 +298,7 @@ export class Helios extends Device {
   }
 
   streamDynamic(scene: Scene): void {
+    this.setPointsRate(scene.options.pointsRate);
     const fps = this.pointsRate / MAX_POINTS;
     const frameTime = this.stats.fixedFrameRate.allottedFrameMs = Math.round(1000 / fps);
     const allottedFramePoints = this.stats.fixedFrameRate.allottedFramePoints = Math.round(this.pointsRate / fps);
@@ -347,7 +348,7 @@ export class Helios extends Device {
       const funcDuration = Date.now() - funcStart;
       const remainingFrameTime = frameTime - funcDuration;
       const adjustedRemainingFrameTime = remainingFrameTime + retryAdjustment;
-      console.log(frameTime, funcDuration, remainingFrameTime, retryAdjustment, adjustedRemainingFrameTime);
+      //console.log(frameTime, funcDuration, remainingFrameTime, retryAdjustment, adjustedRemainingFrameTime);
       this.interval = setTimeout(streamSingle, adjustedRemainingFrameTime);
     };
     this.interval = setTimeout(streamSingle, 0);

--- a/packages/helios/src/index.ts
+++ b/packages/helios/src/index.ts
@@ -182,7 +182,7 @@ export class Helios extends Device {
     this.stats.startTime = Date.now();
 
     this.interval = setInterval(() => {
-      const points = scene.points;
+      const points = scene.getPoints(MAX_POINTS);
       const result = this.sendFrame(points, this.pointsRate);
 
       this.stats.lastFrame.points = points.length;

--- a/packages/helios/src/index.ts
+++ b/packages/helios/src/index.ts
@@ -297,6 +297,62 @@ export class Helios extends Device {
     this.stats.allFrames.maxAccel = Math.max(this.stats.allFrames.maxAccel, maxAccel);
   }
 
+  streamDynamic(scene: Scene): void {
+    const fps = this.pointsRate / MAX_POINTS;
+    const frameTime = this.stats.fixedFrameRate.allottedFrameMs = Math.round(1000 / fps);
+    const allottedFramePoints = this.stats.fixedFrameRate.allottedFramePoints = Math.round(this.pointsRate / fps);
+
+    console.log(`Streaming at ${this.pointsRate} pps, ${fps} fps`);
+    console.log(`${frameTime}ms per frame, ${allottedFramePoints} points per frame`);
+
+    this.stats.fixedFrameRate.fps = fps;
+    this.stats.fixedFrameRate.frameAllotmentPercentOfDeviceLimit =
+     100 * allottedFramePoints / MAX_POINTS;
+    this.stats.startTime = Date.now();
+
+    const streamSingle = () => {
+      const funcStart = Date.now();
+      const points = scene.getPoints(MAX_POINTS);
+      const maxTries = 100;
+      let notReadyRetries = 0;
+      let result;
+
+      do {
+        result = this.sendFrame(points, this.pointsRate);
+      } while (result == FrameResult.NotReady && ++notReadyRetries < maxTries);
+
+      if (notReadyRetries > 0) {
+        console.error(`Helios retried ${notReadyRetries} times, refreshing interval.`);
+      }
+
+      this.stats.lastFrame.points = points.length;
+      this.stats.lastFrame.result = result;
+      this.stats.lastFrame.drawMs = 1000 * points.length / this.pointsRate;
+      this.stats.points[result] += points.length;
+      ++this.stats.frames[result];
+
+      this.recordContentStats(points);
+
+      switch (result) {
+        case FrameResult.Fail:
+          console.error("Helios failed sending a frame");
+          break;
+        case FrameResult.NotReady:
+          console.error("Helios not ready.");
+          break;
+      }
+
+      const retryTime = 10; // ms
+      const retryAdjustment = notReadyRetries * retryTime;
+      const funcDuration = Date.now() - funcStart;
+      const remainingFrameTime = frameTime - funcDuration;
+      const adjustedRemainingFrameTime = remainingFrameTime + retryAdjustment;
+      console.log(frameTime, funcDuration, remainingFrameTime, retryAdjustment, adjustedRemainingFrameTime);
+      this.interval = setTimeout(streamSingle, adjustedRemainingFrameTime);
+    };
+    this.interval = setTimeout(streamSingle, 0);
+  }
+
   getStats(): Object {
     return {
       calculated: this.calculateStats(),


### PR DESCRIPTION
Add support for dynamic-length scenes. These group small frames into larger chunks for efficient transfer to the DAC. These also split large scenes into smaller chunks when they're larger than the DAC's max frame size. This also allows animation sync'd to the draw speed of the DAC so that objects will move smoothly even as the duration of a frame changes.